### PR TITLE
Idempotent json importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://datasf.org/showcase/
 
 ## To Do's
 * import by hitting json endpoint, update/append new data
+* look at the data source url, there are attachments with more data/info, like keys/codes and definitions. need to import these as well
 * split ETL part into separate service
 * make `select <col1>, <col2>` work
 * export query results to csv

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://datasf.org/showcase/
 
 
 ## To Do's
+* add indexes!!!
 * import by hitting json endpoint, update/append new data
 * look at the data source url, there are attachments with more data/info, like keys/codes and definitions. need to import these as well
 * split ETL part into separate service

--- a/db/migrate/20180205230450_add_unique_identifier_column.rb
+++ b/db/migrate/20180205230450_add_unique_identifier_column.rb
@@ -1,0 +1,5 @@
+class AddUniqueIdentifierColumn < ActiveRecord::Migration[5.1]
+  def change
+    add_column :data_sources, :unique_identifier_column_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180204003407) do
+ActiveRecord::Schema.define(version: 20180205230450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20180204003407) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "json_endpoint"
+    t.string "unique_identifier_column_name"
   end
 
   create_table "eviction_notices", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,8 @@ data_sources = [
     date_downloaded: Date.new(2018, 1, 24),
     data_freshness_date: Date.new(2017, 8, 9),
     description: "Snapshot of the Mayor’s Office of Housing and Community Development (MOHCD) and the Office of Community Investment and Infrastructure (OCII) affordable housing pipeline projects. The projects listed are in the process of development--or are anticipated to be developed--in partnership with non-profit or for-profit developers and financed through city funding agreements, ground leases, disposition and participation agreements and conduit bond financing. The Affordable Housing Pipeline also includes housing units produced by private developers through the Inclusionary Affordable Housing Program. Data reflects all projects as of FY2016-17.",
-    json_endpoint: "https://data.sfgov.org/resource/e2px-wugd.json"
+    json_endpoint: "https://data.sfgov.org/resource/e2px-wugd.json",
+    unique_identifier_column_name: "project_id"
   },
   {
     title: "Assessor Historical Secured Property Tax Rolls",
@@ -25,7 +26,8 @@ data_sources = [
     date_downloaded: Date.new(2018, 1, 24),
     data_freshness_date: Date.new(2017, 8, 17),
     description: "This data set includes the Office of the Assessor-Recorder’s secured property tax roll spanning from 2007 to 2016. It includes all legally disclosable information, including location of property, value of property, the unique property identifier, and specific property characteristics. The data is used to accurately and fairly appraise all taxable property in the City and County of San Francisco. The Office of the Assessor-Recorder makes no representation or warranty that the information provided is accurate and/or has no errors or omissions. Please see the attached documentation under About for more.",
-    json_endpoint: "https://data.sfgov.org/resource/fk72-cxc3.json"
+    json_endpoint: "https://data.sfgov.org/resource/fk72-cxc3.json",
+    unique_identifier_column_name: ""
   },
   {
     title: "Buyout agreements",
@@ -35,7 +37,8 @@ data_sources = [
     date_downloaded: Date.new(2018, 1, 24),
     data_freshness_date: Date.new(2017, 12, 28),
     description: "Contains buyout declarations and buyout agreements filed at the Rent Board. Rent Ordinance Section 37.9E, effective March 7, 2015, is a new provision that regulates 'buyout agreements' between landlords and tenants under which landlords pay tenants money or other consideration to vacate their rent-controlled rental units. For more information, please see: http://sfrb.org/new-ordinance-amendment-regulating-buyout-agreements",
-    json_endpoint: "https://data.sfgov.org/resource/e27i-hcy4.json"
+    json_endpoint: "https://data.sfgov.org/resource/e27i-hcy4.json",
+    unique_identifier_column_name: ""
   },
   {
     title: "Eviction Notices",
@@ -45,7 +48,8 @@ data_sources = [
     date_downloaded: Date.new(2018, 1, 24),
     data_freshness_date: Date.new(2017, 12, 28),
     description: "Data includes eviction notices filed with the San Francisco Rent Board per San Francisco Administrative Code 37.9(c). A notice of eviction does not necessarily indicate that the tenant was eventually evicted, so the notices below may differ from actual evictions. Notices are published since January 1, 1997.",
-    json_endpoint: "https://data.sfgov.org/resource/93gi-sfd2.json"
+    json_endpoint: "https://data.sfgov.org/resource/93gi-sfd2.json",
+    unique_identifier_column_name: "eviction_id"
   },
   {
     title: "Building Permits",
@@ -55,7 +59,8 @@ data_sources = [
     date_downloaded: Date.new(2018, 1, 24),
     data_freshness_date: Date.new(2018, 1, 20),
     description: "This data set pertains to all types of structural permits. Data includes details on application/permit numbers, job addresses, supervisorial districts, and the current status of the applications. Data is uploaded weekly by DBI. Users can access permit information online through DBI’s Permit Tracking System which is 24/7 at www.sfdbi.org/dbipts.",
-    json_endpoint: "https://data.sfgov.org/resource/vy2q-29it.json"
+    json_endpoint: "https://data.sfgov.org/resource/vy2q-29it.json",
+    unique_identifier_column_name: ""
   },
 ]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,7 +27,7 @@ data_sources = [
     data_freshness_date: Date.new(2017, 8, 17),
     description: "This data set includes the Office of the Assessor-Recorder’s secured property tax roll spanning from 2007 to 2016. It includes all legally disclosable information, including location of property, value of property, the unique property identifier, and specific property characteristics. The data is used to accurately and fairly appraise all taxable property in the City and County of San Francisco. The Office of the Assessor-Recorder makes no representation or warranty that the information provided is accurate and/or has no errors or omissions. Please see the attached documentation under About for more.",
     json_endpoint: "https://data.sfgov.org/resource/fk72-cxc3.json",
-    unique_identifier_column_name: ""
+    unique_identifier_column_name: "block_and_lot_number"
   },
   {
     title: "Buyout agreements",
@@ -38,7 +38,7 @@ data_sources = [
     data_freshness_date: Date.new(2017, 12, 28),
     description: "Contains buyout declarations and buyout agreements filed at the Rent Board. Rent Ordinance Section 37.9E, effective March 7, 2015, is a new provision that regulates 'buyout agreements' between landlords and tenants under which landlords pay tenants money or other consideration to vacate their rent-controlled rental units. For more information, please see: http://sfrb.org/new-ordinance-amendment-regulating-buyout-agreements",
     json_endpoint: "https://data.sfgov.org/resource/e27i-hcy4.json",
-    unique_identifier_column_name: ""
+    unique_identifier_column_name: "case_number"
   },
   {
     title: "Eviction Notices",
@@ -60,8 +60,11 @@ data_sources = [
     data_freshness_date: Date.new(2018, 1, 20),
     description: "This data set pertains to all types of structural permits. Data includes details on application/permit numbers, job addresses, supervisorial districts, and the current status of the applications. Data is uploaded weekly by DBI. Users can access permit information online through DBI’s Permit Tracking System which is 24/7 at www.sfdbi.org/dbipts.",
     json_endpoint: "https://data.sfgov.org/resource/vy2q-29it.json",
-    unique_identifier_column_name: ""
+    unique_identifier_column_name: "record_id"
   },
 ]
 
-DataSource.create(data_sources)
+data_sources.each do |data_source|
+  d = DataSource.where(title: data_source[:title]).first_or_initialize
+  d.update(data_source)
+end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,8 +1,0 @@
-require 'csv_importer'
-
-desc "Import csv"
-task :import_csv, [:file_path] => :environment do |_, args|
-  # args.with_defaults(file_path: 'opt/police_data/sample_police_data.csv')
-  args.with_defaults(file_path: 'opt/police_data/Police_Department_Incidents.csv')
-  CsvImporter.new(args[:file_path]).process
-end

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -1,0 +1,14 @@
+require "csv_importer"
+require_relative "../../opt/import_data"
+
+desc "Import csv"
+task :import_csv, [:file_path] => :environment do |_, args|
+  # args.with_defaults(file_path: 'opt/police_data/sample_police_data.csv')
+  args.with_defaults(file_path: "opt/police_data/Police_Department_Incidents.csv")
+  CsvImporter.new(args[:file_path]).process
+end
+
+desc "Import JSON"
+task import_json: :environment do
+  ImportData.new("sf_gov_open_data_dev").process
+end

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -91,7 +91,7 @@ class ImportData
     expected_table_counts = {
       building_permits: 1000,
       eviction_notices: 1000,
-      assessor_historical_secured_property_tax_roles: 1000,
+      assessor_historical_secured_property_tax_roles: 978,
       buyout_agreements: 857,
       affordable_housing_pipeline: 299
     }
@@ -99,13 +99,15 @@ class ImportData
     DataSource.all.each do |data_source|
       result = @connection.exec("select count(*) from #{data_source.table_name}").values[0][0].to_i
 
-      puts "\n=========="
       if result != expected_table_counts[data_source.table_name.to_sym]
-        puts "\e[1;31mExpected count for #{data_source.table_name} #{expected_table_counts[data_source.table_name.to_sym]}, actual count: #{result}"
+        puts "\n\e[1;31m=========="
+        puts "Expected count for #{data_source.table_name} #{expected_table_counts[data_source.table_name.to_sym]}, actual count: #{result}"
+        puts "==========\n"
       else
-        puts "\e[1;32mYay! Expected count #{expected_table_counts[data_source.table_name.to_sym]} (#{data_source.table_name}) matches actual count: #{result}"
+        puts "\n\e[1;32m=========="
+        puts "Yay! Expected count #{expected_table_counts[data_source.table_name.to_sym]} (#{data_source.table_name}) matches actual count: #{result}"
+        puts "==========\n"
       end
-      puts "==========\n"
     end
   end
 end

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -4,22 +4,30 @@ require 'pg'
 require 'pry'
 
 class ImportData
-  def initialize(database_name, drop_table=false)
+  def initialize(database_name, drop_tables=false)
     @connection = PG.connect(dbname: database_name)
-    @drop_table = drop_table
+    @drop_table = drop_tables
   end
 
-  def json_response
-    response = Net::HTTP.get(URI(@url))
+  def json_response(url)
+    response = Net::HTTP.get(URI(url))
     puts "parsing json response..."
-    @results ||= JSON.parse(response)
+    JSON.parse(response)
   end
 
   def process
-    rollback if @drop_table
-    json_response
-    create_table
+  	DataSource.all.each do |data_source|
+  	  rollback(data_source.table_name) if @drop_tables
 
+  	  results = json_response(data_source.json_endpoint)
+      table_columns = results.first.keys.map!{ |c| c.sub(/:@/,'') }
+
+  	  create_table(data_source.table_name, table_columns)
+  	  insert_rows(data_source, table_columns, results)
+    end
+  end
+
+  def insert_rows(data_source, table_columns, results)
     puts "inserting values into table..."
     @connection.prepare('insert_statement', "insert into #{@table_name} (#{table_columns.join(', ')}) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)")
     @results.each do |row|
@@ -30,14 +38,10 @@ class ImportData
 
   private
 
-  def table_columns
-    @table_columns ||= @results.first.keys.map!{ |c| c.sub(/:@/,'') }
-  end
-
-  def create_table
+  def create_table(table_name, table_columns)
     puts "creating table...."
 
-    create_table_sql = "create table if not exists #{@table_name} ("
+    create_table_sql = "create table if not exists #{table_name} ("
     create_table_sql += "id serial primary key,"
     create_table_sql += (table_columns.join(" varchar(255), ") + " varchar(255)")
     create_table_sql += ");"
@@ -45,10 +49,8 @@ class ImportData
     @connection.exec(create_table_sql)
   end
 
-  def rollback
-    @connection.exec("drop table #{@table_name}") 
+  def rollback(table_name)
+    @connection.exec("drop table #{table_name}")
   end
 end
 
-i = ImportSFPoliceData.new
-i.process

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -50,19 +50,12 @@ class ImportData
         end
       end
 
-      # START HERE: ================================================================================
-      # => not sure why getting this error on step 5 below:
-      #    PG::DuplicatePstatement: ERROR:  prepared statement
-      #    "insert_statement_assessor_historical_secured_property_tax_roles_3593007"
-      #    already exists
-      # => only happening on assessor_historical_secured_property_tax_roles table
-      # ============================================================================================
-
       unique_identifier_for_prepared_stmt = row["#{data_source.unique_identifier_column_name}"]
-      prepared_insert_name = "insert_statement_#{data_source.table_name}_#{unique_identifier_for_prepared_stmt}"
-      @connection.prepare(prepared_insert_name, prepared_insert)
+      prepared_insert_name = "insert_statement_#{data_source.table_name}_#{(unique_identifier_for_prepared_stmt).delete('-')}"
 
+      @connection.prepare(prepared_insert_name, prepared_insert)
       @connection.exec_prepared(prepared_insert_name, row.values)
+      @connection.exec("deallocate all")
     end
   end
 

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -3,11 +3,10 @@ require 'json'
 require 'pg'
 require 'pry'
 
-class ImportSFPoliceData
-  def initialize(url='https://data.sfgov.org/resource/cuks-n6tp.json')
-    @url = url
-    @connection = PG.connect(dbname: 'sf_police_data_development')
-    @table_name = 'original_sf_gov_data'
+class ImportData
+  def initialize(database_name, drop_table=false)
+    @connection = PG.connect(dbname: database_name)
+    @drop_table = drop_table
   end
 
   def json_from_file
@@ -23,7 +22,7 @@ class ImportSFPoliceData
   end
 
   def process
-    rollback
+    rollback if @drop_table
     json_response
     create_table
 
@@ -53,7 +52,7 @@ class ImportSFPoliceData
   end
 
   def rollback
-    @connection.exec("drop table #{@table_name}")
+    @connection.exec("drop table #{@table_name}") 
   end
 end
 

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -25,6 +25,8 @@ class ImportData
       create_table(data_source.table_name, json_columns)
       insert_rows(data_source, results)
     end
+
+    test_results
   end
 
   def insert_rows(data_source, results)
@@ -83,6 +85,28 @@ class ImportData
   def rollback(table_name)
     @connection.exec("drop table #{table_name}")
     puts "\ndropping table #{table_name}"
+  end
+
+  def test_results
+    expected_table_counts = {
+      building_permits: 1000,
+      eviction_notices: 1000,
+      assessor_historical_secured_property_tax_roles: 1000,
+      buyout_agreements: 857,
+      affordable_housing_pipeline: 299
+    }
+
+    DataSource.all.each do |data_source|
+      result = @connection.exec("select count(*) from #{data_source.table_name}").values[0][0].to_i
+
+      puts "\n=========="
+      if result != expected_table_counts[data_source.table_name.to_sym]
+        puts "\e[1;31mExpected count for #{data_source.table_name} #{expected_table_counts[data_source.table_name.to_sym]}, actual count: #{result}"
+      else
+        puts "\e[1;32mYay! Expected count #{expected_table_counts[data_source.table_name.to_sym]} (#{data_source.table_name}) matches actual count: #{result}"
+      end
+      puts "==========\n"
+    end
   end
 end
 

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -9,12 +9,6 @@ class ImportData
     @drop_table = drop_table
   end
 
-  def json_from_file
-    puts "reading the json file..."
-    file = File.read("/Users/jzhong/Documents/jacinda/sf_police_data/opt/police_data/original_sf_gov_data.json")
-    @results = JSON.parse(file)
-  end
-
   def json_response
     response = Net::HTTP.get(URI(@url))
     puts "parsing json response..."

--- a/opt/import_data.rb
+++ b/opt/import_data.rb
@@ -54,7 +54,7 @@ class ImportData
 
     create_table_sql = "create table if not exists #{table_name} ("
     create_table_sql += "id serial primary key,"
-    create_table_sql += (json_columns.join(" varchar(255), ") + " varchar(255)")
+    create_table_sql += (json_columns.join(" text, ") + " text")
     create_table_sql += ");"
     @connection.exec(create_table_sql)
 


### PR DESCRIPTION
### Import JSON data from sf open data endpoints:
* can drop/create tables depending on if they exist or not
* builds `prepare` statement grouped by rows that have the same keys (since the JSON payload doesn't have consistent keys, and also differs from a CSV export)
* can append/update rows depending on if they exist or not
* uses `data_sources.unique_identifier_column_name` to see if a row exists or not
* does _rough_ checks to ensure row count is as expected